### PR TITLE
Update thread_safe_queue.h

### DIFF
--- a/s4_thread_safe_queue/thread_safe_queue.h
+++ b/s4_thread_safe_queue/thread_safe_queue.h
@@ -49,6 +49,9 @@ class sequential_queue1 {
 		std::shared_ptr<T> const res(std::make_shared<T>(std::move(head->data)));
 		std::unique_ptr<node> const old_head = std::move(head);
 		head = std::move(old_head->next);
+		if(!head) {
+			tail = nullptr;
+		}
 		return res;
 	}
 };


### PR DESCRIPTION
tail = nullptr, when last head was poped.
Once all elements have been retrieved using pop(), no more can be added. The reason seems to be that the tail pointer was not updated when the last element of the queue was fetched.